### PR TITLE
Add main page skeleton for Whisky Tracker PWA

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Whisky Tracker</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="icon" href="https://cdn-icons-png.flaticon.com/512/3737/3737372.png">
+</head>
+<body>
+  <div class="hero">
+    <div class="overlay">
+      <h1>Whisky Tracker</h1>
+      <p class="tagline">Track your single malt journey</p>
+    </div>
+  </div>
+  <section class="gallery">
+    <img src="https://images.unsplash.com/photo-1518173946687-a4c8892bbd73?auto=format&fit=crop&w=600&q=80" alt="Whisky glass">
+    <img src="https://images.unsplash.com/photo-1601585154340-464cd4a5fcbb?auto=format&fit=crop&w=600&q=80" alt="Whisky bottle">
+    <img src="https://images.unsplash.com/photo-1509664528900-4ca50070fda5?auto=format&fit=crop&w=600&q=80" alt="Whisky barrel">
+  </section>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Whisky Tracker",
+  "short_name": "Whisky",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#1a1a1a",
+  "theme_color": "#1a1a1a",
+  "icons": [
+    {
+      "src": "https://cdn-icons-png.flaticon.com/512/3737/3737372.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://cdn-icons-png.flaticon.com/512/3737/3737372.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,7 @@
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,51 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
+
+body, html {
+  margin: 0;
+  padding: 0;
+  font-family: 'Playfair Display', serif;
+  color: #fff;
+  background-color: #111;
+}
+
+.hero {
+  height: 100vh;
+  background: url('https://images.unsplash.com/photo-1528712306091-ed0763094c98?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+  position: relative;
+}
+
+.hero .overlay {
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+h1 {
+  font-size: 4rem;
+  margin: 0;
+}
+
+.tagline {
+  font-size: 1.5rem;
+}
+
+.gallery {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  background: #1a1a1a;
+}
+
+.gallery img {
+  width: 30%;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- Add classy landing page with hero image, whisky gallery, and title.
- Introduce styling, PWA manifest, and basic service worker registration for future functionality.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a388f4f6548323bd20635431248231